### PR TITLE
fix: derive accessibility test colors from theme JSON

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,6 +4,7 @@ module.exports = {
   testEnvironment: 'node',
   roots: ['<rootDir>/tests'],
   testMatch: ['**/*.test.ts'],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   collectCoverageFrom: [
     'tests/**/*.ts',
     'src/**/*.ts',

--- a/tests/accessibility.test.ts
+++ b/tests/accessibility.test.ts
@@ -13,6 +13,17 @@ describe('WCAG Accessibility Compliance', () => {
     theme = JSON.parse(themeContent);
   });
 
+  const requireTokenColor = (scopeName: string): string => {
+    const color = validator.findTokenColor(theme, scopeName);
+    expect(color).toBeDefined();
+
+    if (!color) {
+      throw new Error(`Missing token color for scope "${scopeName}" in theme.tokenColors`);
+    }
+
+    return color;
+  };
+
   describe('WCAG AA Compliance (4.5:1 ratio)', () => {
     test('editor text should meet AA contrast requirements', () => {
       const background = theme.colors['editor.background'];
@@ -58,7 +69,7 @@ describe('WCAG Accessibility Compliance', () => {
   describe('Syntax highlighting contrast', () => {
     test('comments should have sufficient contrast', () => {
       const background = theme.colors['editor.background'];
-      const commentColor = '#546e7a';
+      const commentColor = requireTokenColor('comment');
       
       const ratio = validator.getContrastRatio(background, commentColor);
       expect(ratio).toBeGreaterThanOrEqual(2.5); // Relaxed for fog grey nautical aesthetic
@@ -66,7 +77,7 @@ describe('WCAG Accessibility Compliance', () => {
 
     test('strings should have sufficient contrast', () => {
       const background = theme.colors['editor.background'];
-      const stringColor = '#48bb78';
+      const stringColor = requireTokenColor('string');
       
       const ratio = validator.getContrastRatio(background, stringColor);
       expect(ratio).toBeGreaterThanOrEqual(4.5);
@@ -74,7 +85,7 @@ describe('WCAG Accessibility Compliance', () => {
 
     test('keywords should have sufficient contrast', () => {
       const background = theme.colors['editor.background'];
-      const keywordColor = '#7fb3d5';
+      const keywordColor = requireTokenColor('keyword');
       
       const ratio = validator.getContrastRatio(background, keywordColor);
       expect(ratio).toBeGreaterThanOrEqual(4.5);
@@ -82,7 +93,7 @@ describe('WCAG Accessibility Compliance', () => {
 
     test('functions should have sufficient contrast', () => {
       const background = theme.colors['editor.background'];
-      const functionColor = '#5dade2';
+      const functionColor = requireTokenColor('entity.name.function');
       
       const ratio = validator.getContrastRatio(background, functionColor);
       expect(ratio).toBeGreaterThanOrEqual(4.5);
@@ -90,7 +101,12 @@ describe('WCAG Accessibility Compliance', () => {
 
     test('errors should have sufficient contrast', () => {
       const background = theme.colors['editor.background'];
-      const errorColor = '#e53e3e';
+      const errorColor = theme.colors['editorError.foreground'];
+      expect(errorColor).toBeDefined();
+
+      if (!errorColor) {
+        throw new Error('Missing editorError.foreground color in theme.colors');
+      }
       
       const ratio = validator.getContrastRatio(background, errorColor);
       expect(ratio).toBeGreaterThanOrEqual(4.5);

--- a/tests/validators/accessibility-validator.ts
+++ b/tests/validators/accessibility-validator.ts
@@ -69,6 +69,42 @@ export class AccessibilityValidator {
     return colors;
   }
 
+  private normalizeTokenScopes(scope: unknown): string[] {
+    if (typeof scope === 'string') {
+      return scope.split(',').map((value) => value.trim()).filter(Boolean);
+    }
+
+    if (Array.isArray(scope)) {
+      return scope
+        .filter((value): value is string => typeof value === 'string')
+        .flatMap((value) => value.split(',').map((part) => part.trim()).filter(Boolean));
+    }
+
+    return [];
+  }
+
+  findTokenColor(theme: any, scopeName: string): string | undefined {
+    if (!theme?.tokenColors || !Array.isArray(theme.tokenColors)) {
+      return undefined;
+    }
+
+    for (const tokenColor of theme.tokenColors) {
+      const scope = tokenColor?.scope;
+      const foreground = tokenColor?.settings?.foreground;
+
+      if (typeof foreground !== 'string' || !foreground.startsWith('#')) {
+        continue;
+      }
+
+      const scopes = this.normalizeTokenScopes(scope);
+      if (scopes.includes(scopeName)) {
+        return foreground;
+      }
+    }
+
+    return undefined;
+  }
+
   checkColorblindAccessibility(colors: Map<string, string>): string[] {
     const issues: string[] = [];
     
@@ -191,12 +227,12 @@ export class AccessibilityValidator {
       report.recommendations.push(...colorblindIssues);
     }
     
-    const syntaxColors = [
-      ['editor.background', '#48bb78'],
-      ['editor.background', '#7fb3d5'],
-      ['editor.background', '#5dade2'],
-      ['editor.background', '#d4af37'],
-      ['editor.background', '#e53e3e']
+    const syntaxColors: [string, string | undefined][] = [
+      ['editor.background', this.findTokenColor(theme, 'string')],
+      ['editor.background', this.findTokenColor(theme, 'keyword')],
+      ['editor.background', this.findTokenColor(theme, 'entity.name.function')],
+      ['editor.background', this.findTokenColor(theme, 'constant')],
+      ['editor.background', colors.get('editorError.foreground')]
     ];
     
     for (const [bgKey, syntaxColor] of syntaxColors) {


### PR DESCRIPTION
## Summary
- Replace hardcoded syntax colors in accessibility tests with values extracted dynamically from the theme's `tokenColors` array and `colors` object
- Add `findTokenColor()` helper to `AccessibilityValidator` that resolves a scope name (e.g. `string`, `keyword`) to its foreground color from the theme
- Fix 4 of 5 stale color values in tests and 4 of 5 in the validator report, ensuring contrast checks always validate the actual theme palette

Closes #8

## Test plan
- [ ] Run `npm test` and verify all accessibility tests pass
- [ ] Confirm contrast ratios in test output reflect the actual theme colors (`#45b097`, `#7aa3c1`, `#e85d5d`, `#d1a458`)
- [ ] Change a theme color and verify the tests pick up the new value without code changes