### PR TITLE
Fail check:themes when generated files drift

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,20 @@
+name: Check themes
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm test
+      - run: npm run check:themes

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -14,6 +14,7 @@ warp/
 windows-terminal/
 
 # Repo / dev files
+test/
 .git/
 .gitignore
 .github/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to The Flying Dutchman. Format based on
 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/); versioning follows
 [SemVer](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+- `npm run check:themes` now also verifies every generated theme file matches
+  the palette and emitters byte-for-byte. Check mode is read-only: it names
+  missing or stale files and does not rewrite them.
+
 ## [2.0.1]
 
 - Replaced the README status badges — shields.io retired its `visual-studio-marketplace`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to The Flying Dutchman. Format based on
 - `npm run check:themes` now also verifies every generated theme file matches
   the palette and emitters byte-for-byte. Check mode is read-only: it names
   missing or stale files and does not rewrite them.
+- Pointed the README Galleon attribution at https://galleonlabs.io (the old
+  `/fleet/flying-dutchman` path 404ed).
 
 ## [2.0.1]
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,11 +8,13 @@ services. Just JSON/config files, all generated from one palette.
 
 `scripts/palette.mjs` defines every colour, in HSL, once. `scripts/emitters.mjs`
 turns those roles into each editor's format. `scripts/build-themes.mjs` writes
-every file and can print a WCAG report.
+every file; `--check` prints a WCAG report and verifies committed outputs
+without rewriting them.
 
 ```bash
 npm run build:themes    # regenerate all editors + all 3 variants
-npm run check:themes    # WCAG contrast report (non-zero exit on AA failure)
+npm run check:themes    # WCAG + byte-identical generated files (read-only; non-zero on AA or drift)
+npm test                # clean tree passes; stale/missing generated files fail without being rewritten
 ```
 
 **Never hand-edit a generated theme file.** Change `palette.mjs`, rebuild, commit
@@ -24,7 +26,7 @@ the palette change and the regenerated output together.
 scripts/
   palette.mjs      # HSL master palette — the only place colours are decided
   emitters.mjs     # role -> VS Code / ghostty / iterm / warp / wt / vim / sublime
-  build-themes.mjs # writes every file; --check prints the contrast report
+  build-themes.mjs # writes every file; --check is read-only (WCAG + artifact match)
 themes/            # 3 generated VS Code variants (standard, high-contrast, soft)
 ghostty/ iterm/ sublime-text/ vim/ warp/ windows-terminal/   # generated ports
 screenshots/       # hero.png used by the README (absolute raw URL)
@@ -39,7 +41,8 @@ package.json       # pure theme contribution (contributes.themes only)
   no colour shouts. Warm brass/gold and a single coral anchor an otherwise cool
   ocean palette.
 - **AA everywhere.** Every role clears 4.5:1 against its editor background;
-  comments/punctuation may sit at AA-large (3:1). `check:themes` enforces it.
+  comments/punctuation may sit at AA-large (3:1). `check:themes` enforces it
+  and that committed generated files still match the palette and emitters.
 
 ## Publishing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,8 +10,13 @@ Every file under `themes/`, `ghostty/`, `iterm/`, `sublime-text/`, `vim/`,
 
 ```bash
 node scripts/build-themes.mjs          # regenerate every editor + variant
-node scripts/build-themes.mjs --check  # WCAG contrast report (exits non-zero on AA failure)
+node scripts/build-themes.mjs --check  # WCAG report + byte-identical generated files (read-only)
+npm test                               # clean tree passes; stale/missing generated files fail without being rewritten
 ```
+
+`--check` never creates, overwrites, or repairs generated files. It exits
+non-zero and names the path when any output is missing or does not match the
+palette and emitters exactly.
 
 There are no dependencies to install — the scripts are plain Node ESM.
 
@@ -22,8 +27,9 @@ There are no dependencies to install — the scripts are plain Node ESM.
    everywhere consistently.
 2. Run `node scripts/build-themes.mjs` and commit the regenerated files together
    with the palette change.
-3. Keep every role at **≥ 4.5:1** against its editor background (`--check` enforces
-   this). Comments and punctuation may sit at AA-large (3:1).
+3. Keep every role at **≥ 4.5:1** against its editor background (`--check`
+   enforces this, and that generated files still match). Comments and
+   punctuation may sit at AA-large (3:1).
 
 ## Adding an editor
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ can never drift apart across editors or variants:
 
 ```bash
 npm run build:themes    # regenerate all editors from scripts/palette.mjs
-npm run check:themes     # print the WCAG contrast report
+npm run check:themes     # WCAG report; committed files must match the palette (read-only)
 ```
 
 To adjust a colour, edit [`scripts/palette.mjs`](scripts/palette.mjs) and rebuild —

--- a/README.md
+++ b/README.md
@@ -82,5 +82,5 @@ MIT — see [LICENSE](LICENSE).
 <div align="center">
 <sub><i>"Part of the ship, part of the crew."</i></sub>
 
-<sub><a href="https://galleonlabs.io/fleet/flying-dutchman">by Galleon</a></sub>
+<sub><a href="https://galleonlabs.io">by Galleon Labs</a></sub>
 </div>

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "scripts": {
         "build:themes": "node scripts/build-themes.mjs",
         "check:themes": "node scripts/build-themes.mjs --check",
+        "test": "node --test test/check-themes.test.mjs",
         "vscode:prepublish": "node scripts/build-themes.mjs",
         "package": "vsce package",
         "publish": "vsce publish"

--- a/scripts/build-themes.mjs
+++ b/scripts/build-themes.mjs
@@ -1,9 +1,11 @@
 #!/usr/bin/env node
 // Build every editor theme from the master palette.
 // Usage: node scripts/build-themes.mjs [--check]
-//   --check  print a WCAG contrast report and exit non-zero on AA failures
+//   --check  print a WCAG contrast report and verify committed outputs match
+//            the palette/emitters. Read-only: never writes or repairs files.
+//            Exits non-zero on AA failures or stale/missing generated files.
 
-import { writeFileSync, mkdirSync } from 'node:fs';
+import { writeFileSync, mkdirSync, readFileSync, existsSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { palette, variants } from './palette.mjs';
@@ -66,21 +68,49 @@ function report() {
   return failures;
 }
 
-// --- build --------------------------------------------------------------
-function build() {
-  const written = [];
+// --- artifacts ----------------------------------------------------------
+// One in-memory list drives both write and check so they cannot diverge.
+function artifacts() {
+  const out = [];
   for (const v of variants) {
-    written.push(write(FILE[v], json(vscodeTheme(DISPLAY[v], palette(v)))));
+    out.push([FILE[v], json(vscodeTheme(DISPLAY[v], palette(v)))]);
   }
   const std = palette('standard');
   const name = 'The Flying Dutchman';
-  written.push(write('ghostty/The-Flying-Dutchman', ghostty(std)));
-  written.push(write('warp/the-flying-dutchman.yaml', warp(name, std)));
-  written.push(write('windows-terminal/The-Flying-Dutchman.json', json(windowsTerminal(name, std))));
-  written.push(write('iterm/The-Flying-Dutchman.itermcolors', iterm(std)));
-  written.push(write('vim/colors/flying-dutchman.vim', vim(std)));
-  written.push(write('sublime-text/The-Flying-Dutchman.tmTheme', sublime(name, std)));
-  return written;
+  out.push(['ghostty/The-Flying-Dutchman', ghostty(std)]);
+  out.push(['warp/the-flying-dutchman.yaml', warp(name, std)]);
+  out.push(['windows-terminal/The-Flying-Dutchman.json', json(windowsTerminal(name, std))]);
+  out.push(['iterm/The-Flying-Dutchman.itermcolors', iterm(std)]);
+  out.push(['vim/colors/flying-dutchman.vim', vim(std)]);
+  out.push(['sublime-text/The-Flying-Dutchman.tmTheme', sublime(name, std)]);
+  return out;
+}
+
+function build() {
+  return artifacts().map(([rel, contents]) => write(rel, contents));
+}
+
+// Read-only: compare committed files to the in-memory expected output.
+// Never creates, overwrites, or repairs anything on disk.
+function checkArtifacts() {
+  const missing = [];
+  const stale = [];
+  for (const [rel, contents] of artifacts()) {
+    const path = resolve(root, rel);
+    if (!existsSync(path)) {
+      missing.push(rel);
+      continue;
+    }
+    let actual;
+    try {
+      actual = readFileSync(path);
+    } catch {
+      stale.push(rel);
+      continue;
+    }
+    if (!actual.equals(Buffer.from(contents))) stale.push(rel);
+  }
+  return { missing, stale };
 }
 
 const checkOnly = process.argv.includes('--check');
@@ -89,7 +119,22 @@ if (!checkOnly) {
   console.log('Wrote:');
   for (const f of written) console.log(`  ${f}`);
 }
+
+let drift = 0;
+if (checkOnly) {
+  const { missing, stale } = checkArtifacts();
+  if (missing.length || stale.length) {
+    drift = 1;
+    console.log('Generated outputs do not match the palette and emitters:');
+    for (const f of missing) console.log(`  missing  ${f}`);
+    for (const f of stale) console.log(`  stale    ${f}`);
+    console.log('\nRun `npm run build:themes` to regenerate, then commit the result.');
+  } else {
+    console.log(`All ${artifacts().length} generated file(s) match the palette and emitters.`);
+  }
+}
+
 console.log('\nWCAG contrast (syntax & text vs editor background):');
 const failures = report();
 console.log(`\n${failures === 0 ? 'All roles pass their WCAG target.' : `${failures} role(s) below target.`}`);
-process.exit(checkOnly && failures ? 1 : 0);
+process.exit(checkOnly && (failures || drift) ? 1 : 0);

--- a/test/check-themes.test.mjs
+++ b/test/check-themes.test.mjs
@@ -55,8 +55,9 @@ test('generated-artifact check', async (t) => {
     const before = snapshot();
     const result = runCheck();
     assert.equal(result.status, 0, result.stdout + result.stderr);
-    assert.match(result.stdout, /match the palette and emitters/);
+    assert.match(result.stdout, /All 9 generated file\(s\) match the palette and emitters/);
     assert.match(result.stdout, /WCAG contrast/);
+    assert.doesNotMatch(result.stdout, /Wrote:/);
     assertSnapshotEqual(before, snapshot(), 'check mode must not rewrite a clean tree');
   });
 
@@ -71,6 +72,8 @@ test('generated-artifact check', async (t) => {
       const result = runCheck();
       assert.notEqual(result.status, 0);
       assert.match(`${result.stdout}\n${result.stderr}`, /stale\s+ghostty\/The-Flying-Dutchman/);
+      assert.match(`${result.stdout}\n${result.stderr}`, /WCAG contrast/);
+      assert.doesNotMatch(result.stdout, /Wrote:/);
       assertSnapshotEqual(before, snapshot(), 'check mode must not repair a stale file');
       assert.ok(readFileSync(target).equals(drifted));
     } finally {
@@ -88,6 +91,8 @@ test('generated-artifact check', async (t) => {
       const result = runCheck();
       assert.notEqual(result.status, 0);
       assert.match(`${result.stdout}\n${result.stderr}`, /missing\s+warp\/the-flying-dutchman.yaml/);
+      assert.match(`${result.stdout}\n${result.stderr}`, /WCAG contrast/);
+      assert.doesNotMatch(result.stdout, /Wrote:/);
       assert.equal(existsSync(target), false, 'check mode must not recreate a missing file');
       assertSnapshotEqual(before, snapshot(), 'check mode must not create missing files');
     } finally {

--- a/test/check-themes.test.mjs
+++ b/test/check-themes.test.mjs
@@ -1,0 +1,97 @@
+// Regression: --check is read-only and fails on stale or missing outputs.
+// Subtests are awaited so they stay sequential if the runner is concurrent.
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const script = resolve(root, 'scripts/build-themes.mjs');
+
+const GENERATED = [
+  'themes/flying-dutchman-color-theme.json',
+  'themes/flying-dutchman-high-contrast.json',
+  'themes/flying-dutchman-soft.json',
+  'ghostty/The-Flying-Dutchman',
+  'warp/the-flying-dutchman.yaml',
+  'windows-terminal/The-Flying-Dutchman.json',
+  'iterm/The-Flying-Dutchman.itermcolors',
+  'vim/colors/flying-dutchman.vim',
+  'sublime-text/The-Flying-Dutchman.tmTheme',
+];
+
+function snapshot() {
+  const files = {};
+  for (const rel of GENERATED) {
+    const path = resolve(root, rel);
+    files[rel] = existsSync(path) ? readFileSync(path) : null;
+  }
+  return files;
+}
+
+function assertSnapshotEqual(before, after, message) {
+  assert.deepEqual(Object.keys(after), Object.keys(before), message);
+  for (const rel of Object.keys(before)) {
+    if (before[rel] === null) {
+      assert.equal(after[rel], null, `${rel} should still be missing`);
+    } else {
+      assert.ok(after[rel] && before[rel].equals(after[rel]), `${rel} was modified`);
+    }
+  }
+}
+
+function runCheck() {
+  return spawnSync(process.execPath, [script, '--check'], {
+    cwd: root,
+    encoding: 'utf8',
+  });
+}
+
+test('generated-artifact check', async (t) => {
+  await t.test('clean tree passes and writes nothing', () => {
+    const before = snapshot();
+    const result = runCheck();
+    assert.equal(result.status, 0, result.stdout + result.stderr);
+    assert.match(result.stdout, /match the palette and emitters/);
+    assert.match(result.stdout, /WCAG contrast/);
+    assertSnapshotEqual(before, snapshot(), 'check mode must not rewrite a clean tree');
+  });
+
+  await t.test('stale generated file fails without being repaired', () => {
+    const targetRel = 'ghostty/The-Flying-Dutchman';
+    const target = resolve(root, targetRel);
+    const original = readFileSync(target);
+    const drifted = Buffer.concat([original, Buffer.from('\n# drifted\n')]);
+    writeFileSync(target, drifted);
+    try {
+      const before = snapshot();
+      const result = runCheck();
+      assert.notEqual(result.status, 0);
+      assert.match(`${result.stdout}\n${result.stderr}`, /stale\s+ghostty\/The-Flying-Dutchman/);
+      assertSnapshotEqual(before, snapshot(), 'check mode must not repair a stale file');
+      assert.ok(readFileSync(target).equals(drifted));
+    } finally {
+      writeFileSync(target, original);
+    }
+  });
+
+  await t.test('missing generated file fails without being created', () => {
+    const targetRel = 'warp/the-flying-dutchman.yaml';
+    const target = resolve(root, targetRel);
+    const original = readFileSync(target);
+    unlinkSync(target);
+    try {
+      const before = snapshot();
+      const result = runCheck();
+      assert.notEqual(result.status, 0);
+      assert.match(`${result.stdout}\n${result.stderr}`, /missing\s+warp\/the-flying-dutchman.yaml/);
+      assert.equal(existsSync(target), false, 'check mode must not recreate a missing file');
+      assertSnapshotEqual(before, snapshot(), 'check mode must not create missing files');
+    } finally {
+      writeFileSync(target, original);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`npm run check:themes` now proves committed generated outputs still match `scripts/palette.mjs` and the emitters, without rewriting anything.

Reuses the stalled work from #13 on `barbossa/fleet/` so it can be reviewed and merged. Adds a minimal GitHub Actions workflow so the check actually runs on PRs and `main` (2.0 removed the old Jest workflow; nothing has run on `main` since).

- `--check` compares every generated file byte-for-byte to the in-memory expected output and exits non-zero with `missing` / `stale` path names.
- Check mode is read-only: it does not create, overwrite, or repair generated files.
- Build mode and the WCAG contrast report are unchanged.
- `npm test` (Node's built-in runner, no new dependencies) covers a clean tree passing and a deliberately stale or missing artifact failing without being modified.

Closes the gap #13 targeted. Supersedes #13.

## Verification

```
npm test
# 4 pass: clean tree; stale file not repaired; missing file not created

npm run check:themes
# All 9 generated file(s) match the palette and emitters.
# All roles pass their WCAG target.

npm run build:themes
git status --short
# only the intended source/test/docs/CI files
```

Palette values and generated theme output were not edited.

## Out of scope

No marketplace publish. Package remains 2.0.1; changelog records this under Unreleased.