### PR TITLE
Cut 2.0.2 for the stalled Marketplace listing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to The Flying Dutchman. Format based on
 
 ## [Unreleased]
 
+## [2.0.2]
+
 - `npm run check:themes` now also verifies every generated theme file matches
   the palette and emitters byte-for-byte. Check mode is read-only: it names
   missing or stale files and does not rewrite them.
@@ -13,6 +15,9 @@ All notable changes to The Flying Dutchman. Format based on
   `/fleet/flying-dutchman` path 404ed).
 
 ## [2.0.1]
+
+Recorded here but never published to the Marketplace, which served 2.0.0 from
+2026-07-12; the badge fix below reaches users in 2.0.2.
 
 - Replaced the README status badges — shields.io retired its `visual-studio-marketplace`
   endpoints (they rendered as "retired badge"). Version/installs/rating now use live

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "the-flying-dutchman-theme",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "the-flying-dutchman-theme",
-            "version": "2.0.1",
+            "version": "2.0.2",
             "license": "MIT",
             "devDependencies": {
                 "@vscode/vsce": "^3.2.1"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "the-flying-dutchman-theme",
     "displayName": "The Flying Dutchman",
     "description": "An artisan nautical dark theme. Abyssal ocean blues, aged brass, and a bioluminescent glow — in three harmonious variants. Also ships for six terminals and editors.",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "publisher": "DavyJones",
     "icon": "icon.png",
     "author": {


### PR DESCRIPTION
Refs #16 — implements repo-side steps 1-4 only. Deliberately does **not** close the issue: publishing is step 5 and is maintainer-only.

## What

The Marketplace listing has served **2.0.0** since 2026-07-12 while `main` moved to 2.0.1 plus two unreleased entries, so the shipped badge fix and the corrected Galleon link never reached a user. This cuts the release commit those fixes need.

- `CHANGELOG.md` — the `[Unreleased]` entries move under a new `## [2.0.2]`; `[Unreleased]` is now empty.
- `[2.0.1]` keeps its own entry and gains a note that it was recorded in the changelog but never published, so the changelog stays an honest record of what users actually received. 2.0.1 is rolled forward, not republished. (There is no `v2.0.1` git tag — the only tag in the repo is `v1.3.1` — so the note says "recorded here", not "tagged".)
- `package.json` / `package-lock.json` — root `version` to `2.0.2`. Only the two root `version` fields in the lockfile changed; the other `2.0.1` strings in it are dependency versions (`argparse` and friends) and are untouched.

No palette, emitter, or generated theme file changes — this is a storefront-content release.

## Verification

Run in a clean worktree at this commit:

| Check | Result |
|---|---|
| `npm ci` | clean |
| `npm audit` | 0 vulnerabilities |
| `npm test` | 4/4 pass |
| `npm run check:themes` | 9/9 generated files match the palette; all roles pass their WCAG target; exit 0 and no writes |
| `npm run package` | 9 files, 30.51 KB |

Unpacked `the-flying-dutchman-theme-2.0.2.vsix` and asserted against the acceptance criteria:

- `extension.vsixmanifest` — `Version="2.0.2"` (the `PackageManifest Version="2.0.0"` above it is the vsx schema version, not the extension's)
- packaged `extension/package.json` — `2.0.2`
- packaged `readme.md` — **0** matches for `img.shields.io/visual-studio-marketplace`, **3** for `vsmarketplacebadges.dev`
- packaged `readme.md` — Galleon attribution points at `https://galleonlabs.io`

## Not in this PR

`npm run publish` is step 5 of #16 and is **maintainer-only** — it needs the `DavyJones` publisher PAT, which this automation does not hold and must not use. After this merges, the listing is still on 2.0.0 until a maintainer runs `npm run publish` from `main`. #16 should stay open until the gallery API reads `2.0.2`.

The issue also notes that nothing compares `package.json` against the published Marketplace version, which is why a six-week gap produced no signal. That drift check is a reasonable follow-up and is out of scope here.
