### PR TITLE
Warn when main is ahead of the published Marketplace listing

### DIFF
--- a/.github/workflows/release-drift.yml
+++ b/.github/workflows/release-drift.yml
@@ -1,0 +1,30 @@
+name: Release drift
+
+# Warns when package.json and the served Marketplace listing disagree. Deliberately
+# separate from `Check themes`: that check is the deterministic, offline gate on a PR,
+# and a gallery outage must never be able to block a merge. This one only reports.
+on:
+  push:
+    branches: [main]
+  schedule:
+    # A listing goes stale without any commit, so a push trigger alone would miss it.
+    - cron: '0 9 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-drift
+  cancel-in-progress: true
+
+jobs:
+  drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      # No install: the script is plain Node ESM with no dependencies.
+      - run: node scripts/check-published.mjs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to The Flying Dutchman. Format based on
 
 ## [Unreleased]
 
+- Added `npm run check:published`, which compares `package.json` against the
+  version the Marketplace actually serves. A new `Release drift` workflow runs it
+  on every push to `main` and weekly, so a merged-but-unpublished fix reports
+  itself instead of sitting silently — 2.0.1 went six weeks without reaching a
+  single user. It only warns; an unreachable gallery cannot block a merge.
+
 ## [2.0.2]
 
 - `npm run check:themes` now also verifies every generated theme file matches

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,3 +49,10 @@ package.json       # pure theme contribution (contributes.themes only)
 `npm run package` builds the `.vsix` (prepublish regenerates themes first);
 `npm run publish` pushes to the VS Code Marketplace under the `DavyJones`
 publisher. Bump `version` in `package.json` and add a `CHANGELOG.md` entry first.
+
+Merging is not shipping. `npm run check:published` reports whether the listing
+actually serves what `package.json` claims; the `Release drift` workflow runs it
+on every push to `main` and weekly and warns without ever blocking a merge. After
+publishing, read it back with `npm run check:published -- --strict`, which exits
+non-zero until the gallery serves the current version (allow ~15 min for CDN
+propagation).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,10 @@ npm test                               # clean tree passes; stale/missing genera
 non-zero and names the path when any output is missing or does not match the
 palette and emitters exactly.
 
+`node scripts/check-published.mjs` is separate: it asks the Marketplace what it
+actually serves and warns when `package.json` has moved ahead. It never fails a
+build — add `--strict` to turn it into a post-publish readback.
+
 There are no dependencies to install — the scripts are plain Node ESM.
 
 ## Changing a colour

--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
     "scripts": {
         "build:themes": "node scripts/build-themes.mjs",
         "check:themes": "node scripts/build-themes.mjs --check",
-        "test": "node --test test/check-themes.test.mjs",
+        "check:published": "node scripts/check-published.mjs",
+        "test": "node --test \"test/*.test.mjs\"",
         "vscode:prepublish": "node scripts/build-themes.mjs",
         "package": "vsce package",
         "publish": "vsce publish"

--- a/scripts/check-published.mjs
+++ b/scripts/check-published.mjs
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+// Compare the version in package.json against what the Marketplace actually serves.
+// Usage: node scripts/check-published.mjs [--strict]
+//   default  report only. Exits 0 whatever it finds, so a warning never blocks a merge.
+//   --strict exits non-zero unless the served version equals package.json. Use this as
+//            the readback after `npm run publish`.
+//
+// Nothing else in the repo notices when a merged fix is never published: main sat two
+// releases ahead of the listing for six weeks with no signal. This is that signal.
+
+import { appendFileSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const GALLERY = 'https://marketplace.visualstudio.com/_apis/public/gallery/extensionquery';
+const TIMEOUT_MS = 15000;
+
+// --- pure logic ---------------------------------------------------------
+// Kept free of fs and network so test/check-published.test.mjs never touches either.
+
+// Returns an array of numbers, or null when the tag is not a plain x.y.z we can
+// order. Prerelease and build suffixes are deliberately unparseable: this repo
+// only ships plain releases, and guessing at ordering would be worse than saying
+// so out loud.
+export function parseVersion(tag) {
+  if (typeof tag !== 'string' || !/^\d+(\.\d+)*$/.test(tag.trim())) return null;
+  return tag.trim().split('.').map(Number);
+}
+
+// -1 | 0 | 1, or null when either side is unparseable.
+export function compareVersions(a, b) {
+  const x = parseVersion(a);
+  const y = parseVersion(b);
+  if (!x || !y) return null;
+  for (let i = 0; i < Math.max(x.length, y.length); i += 1) {
+    const d = (x[i] ?? 0) - (y[i] ?? 0);
+    if (d !== 0) return d > 0 ? 1 : -1;
+  }
+  return 0;
+}
+
+// Highest parseable version in the gallery's list. The API returns newest-first
+// today, but ordering is not part of its contract, so pick the max explicitly.
+export function latestVersion(versions) {
+  let best = null;
+  for (const entry of versions ?? []) {
+    const tag = typeof entry === 'string' ? entry : entry?.version;
+    if (!parseVersion(tag)) continue;
+    if (best === null || compareVersions(tag, best) === 1) best = tag;
+  }
+  return best;
+}
+
+// One place decides what every caller reports: status drives the exit code, the
+// annotation level, and the wording.
+export function assess({ local, published, error }) {
+  if (error) {
+    return {
+      status: 'unreachable',
+      ok: false,
+      level: 'warning',
+      message: `Could not read the Marketplace gallery API (${error}). Publish state is unknown, not healthy.`,
+    };
+  }
+  if (!published) {
+    return {
+      status: 'unknown',
+      ok: false,
+      level: 'warning',
+      message: 'The gallery returned no orderable version for this extension. Publish state is unknown, not healthy.',
+    };
+  }
+  const cmp = compareVersions(local, published);
+  if (cmp === null) {
+    return {
+      status: 'unknown',
+      ok: false,
+      level: 'warning',
+      message: `Cannot order package.json ${local} against the served ${published}.`,
+    };
+  }
+  if (cmp === 0) {
+    return {
+      status: 'in-sync',
+      ok: true,
+      level: 'notice',
+      message: `Marketplace serves ${published}, matching package.json.`,
+    };
+  }
+  if (cmp === 1) {
+    return {
+      status: 'unpublished',
+      ok: false,
+      level: 'warning',
+      message:
+        `package.json is ${local} but the Marketplace still serves ${published}. ` +
+        'Every change since that release is unshipped. Run `npm run publish` (needs the publisher PAT).',
+    };
+  }
+  return {
+    status: 'ahead-of-source',
+    ok: false,
+    level: 'warning',
+    message: `The Marketplace serves ${published}, ahead of package.json ${local}. Something published outside this repo.`,
+  };
+}
+
+// --- io -----------------------------------------------------------------
+export async function fetchPublished(extensionId, fetchImpl = fetch) {
+  const response = await fetchImpl(GALLERY, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json;api-version=3.0-preview.1',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      filters: [{ criteria: [{ filterType: 7, value: extensionId }], pageSize: 1, pageNumber: 1 }],
+      flags: 1,
+    }),
+    signal: AbortSignal.timeout(TIMEOUT_MS),
+  });
+  if (!response.ok) throw new Error(`HTTP ${response.status}`);
+  const body = await response.json();
+  return latestVersion(body?.results?.[0]?.extensions?.[0]?.versions);
+}
+
+function annotate({ level, message, status }) {
+  if (!process.env.GITHUB_ACTIONS) return;
+  const escaped = message.replace(/%/g, '%25').replace(/\r/g, '%0D').replace(/\n/g, '%0A');
+  console.log(`::${level} title=Release drift (${status})::${escaped}`);
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    appendFileSync(process.env.GITHUB_STEP_SUMMARY, `**Release drift: ${status}** — ${message}\n`);
+  }
+}
+
+// Only run when invoked directly, so importing for tests stays side-effect free.
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const pkg = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8'));
+  const extensionId = `${pkg.publisher}.${pkg.name}`;
+
+  let published = null;
+  let error = null;
+  try {
+    published = await fetchPublished(extensionId);
+  } catch (err) {
+    error = err?.message ?? String(err);
+  }
+
+  const result = assess({ local: pkg.version, published, error });
+  console.log(`Extension:   ${extensionId}`);
+  console.log(`package.json ${pkg.version}`);
+  console.log(`Marketplace  ${published ?? '(unknown)'}`);
+  console.log(`\n${result.status}: ${result.message}`);
+  annotate(result);
+
+  process.exit(process.argv.includes('--strict') && !result.ok ? 1 : 0);
+}

--- a/test/check-published.test.mjs
+++ b/test/check-published.test.mjs
@@ -1,0 +1,120 @@
+// Regression: drift between package.json and the served Marketplace version is
+// always reported, and an unreachable gallery is reported rather than assumed healthy.
+// No network: fetchPublished is driven with a stub.
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  assess,
+  compareVersions,
+  fetchPublished,
+  latestVersion,
+  parseVersion,
+} from '../scripts/check-published.mjs';
+
+const galleryBody = (versions) => ({
+  results: [{ extensions: [{ versions: versions.map((version) => ({ version })) }] }],
+});
+
+const stubFetch = (body, { ok = true, status = 200 } = {}) => async () => ({
+  ok,
+  status,
+  json: async () => body,
+});
+
+test('version parsing and ordering', async (t) => {
+  await t.test('accepts plain dotted releases', () => {
+    assert.deepEqual(parseVersion('2.0.2'), [2, 0, 2]);
+    assert.deepEqual(parseVersion(' 1.4 '), [1, 4]);
+  });
+
+  await t.test('refuses anything it cannot order', () => {
+    for (const tag of ['2.0.2-rc.1', 'v2.0.2', '', 'latest', undefined, null, 2]) {
+      assert.equal(parseVersion(tag), null, `${tag} should be unparseable`);
+    }
+  });
+
+  await t.test('orders by numeric segment, not string', () => {
+    assert.equal(compareVersions('2.0.10', '2.0.9'), 1);
+    assert.equal(compareVersions('2.0.0', '2.0'), 0);
+    assert.equal(compareVersions('1.4.0', '2.0.0'), -1);
+    assert.equal(compareVersions('2.0.2', 'v2'), null);
+  });
+});
+
+test('latestVersion picks the max, not the first', () => {
+  assert.equal(latestVersion([{ version: '1.4.0' }, { version: '2.0.0' }, { version: '1.3.1' }]), '2.0.0');
+  assert.equal(latestVersion([{ version: '2.0.2-rc.1' }, { version: '2.0.0' }]), '2.0.0');
+  assert.equal(latestVersion([]), null);
+  assert.equal(latestVersion(undefined), null);
+});
+
+test('assess', async (t) => {
+  await t.test('in sync is the only ok status', () => {
+    const result = assess({ local: '2.0.2', published: '2.0.2' });
+    assert.equal(result.status, 'in-sync');
+    assert.equal(result.ok, true);
+  });
+
+  await t.test('source ahead of the listing is the six-week gap this exists to catch', () => {
+    const result = assess({ local: '2.0.2', published: '2.0.0' });
+    assert.equal(result.status, 'unpublished');
+    assert.equal(result.ok, false);
+    assert.equal(result.level, 'warning');
+    assert.match(result.message, /2\.0\.2/);
+    assert.match(result.message, /2\.0\.0/);
+  });
+
+  await t.test('listing ahead of source is also drift', () => {
+    const result = assess({ local: '2.0.0', published: '2.0.2' });
+    assert.equal(result.status, 'ahead-of-source');
+    assert.equal(result.ok, false);
+  });
+
+  await t.test('an unreachable gallery is not healthy', () => {
+    const result = assess({ local: '2.0.2', error: 'HTTP 503' });
+    assert.equal(result.status, 'unreachable');
+    assert.equal(result.ok, false);
+    assert.match(result.message, /HTTP 503/);
+  });
+
+  await t.test('a silent gallery is not healthy either', () => {
+    assert.equal(assess({ local: '2.0.2', published: null }).status, 'unknown');
+    assert.equal(assess({ local: '2.0.2', published: null }).ok, false);
+  });
+
+  await t.test('unorderable versions are reported, not guessed', () => {
+    const result = assess({ local: '2.0.2-rc.1', published: '2.0.0' });
+    assert.equal(result.status, 'unknown');
+    assert.equal(result.ok, false);
+  });
+});
+
+test('fetchPublished', async (t) => {
+  await t.test('asks the gallery for one extension by id', async () => {
+    let seen;
+    const spy = async (url, init) => {
+      seen = { url, init };
+      return { ok: true, status: 200, json: async () => galleryBody(['2.0.0']) };
+    };
+    const version = await fetchPublished('DavyJones.the-flying-dutchman-theme', spy);
+    assert.equal(version, '2.0.0');
+    assert.match(seen.url, /extensionquery$/);
+    const body = JSON.parse(seen.init.body);
+    assert.equal(body.filters[0].criteria[0].value, 'DavyJones.the-flying-dutchman-theme');
+    assert.equal(body.filters[0].criteria[0].filterType, 7);
+  });
+
+  await t.test('throws on a non-ok response so the caller reports unreachable', async () => {
+    await assert.rejects(
+      fetchPublished('DavyJones.the-flying-dutchman-theme', stubFetch(null, { ok: false, status: 503 })),
+      /HTTP 503/,
+    );
+  });
+
+  await t.test('returns null when the extension is absent', async () => {
+    const version = await fetchPublished('DavyJones.nope', stubFetch({ results: [{ extensions: [] }] }));
+    assert.equal(version, null);
+  });
+});


### PR DESCRIPTION
Closes the detection gap named under "Why this drifted" in #16 — the follow-up that issue explicitly left out of scope.

## Why

Nothing in this repo compared `package.json` against the version the Marketplace actually serves. 2.0.1 was merged, changelogged, and never published; the listing served 2.0.0 for six weeks and no check anywhere went red. Merging is not shipping, and until now nothing said so.

This is still live as of this PR:

```
$ node scripts/check-published.mjs
Extension:   DavyJones.the-flying-dutchman-theme
package.json 2.0.2
Marketplace  2.0.0

unpublished: package.json is 2.0.2 but the Marketplace still serves 2.0.0. Every change since that release is unshipped.
```

## What

- **`scripts/check-published.mjs`** — reads the gallery API, orders the served version against `package.json`, and reports one of `in-sync`, `unpublished`, `ahead-of-source`, `unknown`, `unreachable`. Plain Node ESM, no dependencies. In Actions it emits a `::warning` annotation and a step-summary line.
- **`.github/workflows/release-drift.yml`** — runs it on push to `main`, weekly, and on demand. The schedule matters: a listing goes stale without any commit, so a push trigger alone would miss exactly the case that caused #16.
- **`npm run check:published`**, and `-- --strict` for the post-publish readback (non-zero until the gallery serves the current version).
- `npm test` now runs every `test/*.test.mjs`, not just the themes file.

## Design notes for review

- **Separate workflow, warn-only.** `Check themes` stays the deterministic, offline, network-free gate on a PR. A Marketplace outage must never be able to block a merge, so drift reporting lives in its own workflow and always exits 0. `--strict` is opt-in, for a human doing a readback.
- **Unreachable is not healthy.** A failed fetch, an HTTP error, or a gallery that returns no orderable version all report `unknown`/`unreachable` with a warning rather than passing quietly.
- **Unparseable versions are reported, not guessed.** `parseVersion` accepts only plain dotted releases; a prerelease tag yields `unknown` instead of a made-up ordering.
- **Max, not first.** The gallery returns newest-first today, but that is not part of its contract, so `latestVersion` picks the maximum explicitly.
- **No network in tests.** Comparison, parsing, and assessment are pure and exported; `fetchPublished` takes an injectable `fetchImpl`. The 12 new subtests drive it with a stub.

## Verification

Run in a clean worktree at `48fc908` + this commit:

- `npm ci` — clean
- `npm audit` — 0 vulnerabilities
- `npm test` — 20/20 pass (8 existing + 12 new)
- `npm run check:themes` — 9/9 generated files match the palette, all roles pass WCAG
- `npx vsce package` — still 9 files, 30.53 KB; `.vscodeignore` already excludes `scripts/`, `test/`, and `.github/`, so nothing new ships to users
- Actions path exercised with `GITHUB_ACTIONS=1 GITHUB_STEP_SUMMARY=…`: emits `::warning title=Release drift (unpublished)::…` and appends the summary line
- `node scripts/check-published.mjs --strict` exits 1 against the live listing, as it should until 2.0.2 is published

Does not publish anything and does not touch the palette or any generated theme file.