### PR TITLE
Fix the Sublime Text port: it is not valid XML and will not load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to The Flying Dutchman. Format based on
 
 ## [Unreleased]
 
+### Fixed
+
+- The Sublime Text port was not valid XML and would not load. The rule names
+  `Number & Constant` and `Type & Class` wrote a bare `&` into the `.tmTheme`,
+  which every plist parser rejects; it has been broken since the 2.0 redraw.
+  The plist emitters now escape interpolated text, and a new test parses the
+  generated `.tmTheme` and `.itermcolors` for well-formedness — `check:themes`
+  alone could only prove the committed bytes matched the emitters, so a
+  malformed artifact round-tripped clean. Only the repo-served port changed;
+  the `.vsix` never contained these files.
+
 - Added `npm run check:published`, which compares `package.json` against the
   version the Marketplace actually serves. A new `Release drift` workflow runs it
   on every push to `main` and weekly, so a merged-but-unpublished fix reports

--- a/scripts/emitters.mjs
+++ b/scripts/emitters.mjs
@@ -516,6 +516,18 @@ export function windowsTerminal(name, p) {
 }
 
 // ---------------------------------------------------------------------------
+// plist emitters (.itermcolors, .tmTheme)
+// ---------------------------------------------------------------------------
+
+// Both plist formats are real XML, parsed by real XML parsers. Any text we
+// interpolate is a text node, so the three markup characters have to be
+// entities or the file will not parse at all. Rule names like "Number &
+// Constant" shipped a bare `&` and broke the whole .tmTheme.
+function xml(text) {
+  return String(text).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+// ---------------------------------------------------------------------------
 // iTerm2 (.itermcolors plist — sRGB components)
 // ---------------------------------------------------------------------------
 
@@ -553,7 +565,7 @@ export function iterm(p) {
   entries['Cursor Guide Color'] = p.bgLine;
   entries['Badge Color'] = p.coral;
   const body = Object.entries(entries)
-    .map(([k, hex]) => `	<key>${k}</key>\n${itermColor(hex)}`)
+    .map(([k, hex]) => `	<key>${xml(k)}</key>\n${itermColor(hex)}`)
     .join('\n');
   return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -695,9 +707,9 @@ function sublimeRule(name, scope, fg, fontStyle) {
   if (fontStyle) settings.push(`			<key>fontStyle</key>\n			<string>${fontStyle}</string>`);
   return `		<dict>
 			<key>name</key>
-			<string>${name}</string>
+			<string>${xml(name)}</string>
 			<key>scope</key>
-			<string>${scope}</string>
+			<string>${xml(scope)}</string>
 			<key>settings</key>
 			<dict>
 ${settings.join('\n')}
@@ -738,7 +750,7 @@ export function sublime(name, p) {
 <plist version="1.0">
 <dict>
 	<key>name</key>
-	<string>${name}</string>
+	<string>${xml(name)}</string>
 	<key>settings</key>
 	<array>
 		<dict>

--- a/sublime-text/The-Flying-Dutchman.tmTheme
+++ b/sublime-text/The-Flying-Dutchman.tmTheme
@@ -72,7 +72,7 @@
 		</dict>
 		<dict>
 			<key>name</key>
-			<string>Number & Constant</string>
+			<string>Number &amp; Constant</string>
 			<key>scope</key>
 			<string>constant.numeric, constant.language, constant, support.constant</string>
 			<key>settings</key>
@@ -116,7 +116,7 @@
 		</dict>
 		<dict>
 			<key>name</key>
-			<string>Type & Class</string>
+			<string>Type &amp; Class</string>
 			<key>scope</key>
 			<string>entity.name.type, entity.name.class, support.type, support.class, entity.other.inherited-class</string>
 			<key>settings</key>

--- a/test/plist-artifacts.test.mjs
+++ b/test/plist-artifacts.test.mjs
@@ -1,0 +1,73 @@
+// Regression: the .tmTheme and .itermcolors ports are XML, and check:themes only
+// proves the committed bytes match the emitters — a malformed artifact round-trips
+// clean forever. 2.0.0 shipped a Sublime theme that no XML parser would load,
+// because the rule names "Number & Constant" and "Type & Class" wrote a bare `&`.
+
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import { iterm, sublime } from '../scripts/emitters.mjs';
+import { palette } from '../scripts/palette.mjs';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+const PLISTS = ['iterm/The-Flying-Dutchman.itermcolors', 'sublime-text/The-Flying-Dutchman.tmTheme'];
+
+const ENTITY = /^&(amp|lt|gt|quot|apos|#\d+|#x[0-9a-fA-F]+);/;
+
+// Everything outside a <tag> is a text node. Report the offending line so a
+// failure names the rule that broke rather than just the file.
+function textNodeFaults(xml) {
+  const faults = [];
+  let line = 1;
+  let inTag = false;
+  for (let i = 0; i < xml.length; i += 1) {
+    const ch = xml[i];
+    if (ch === '\n') line += 1;
+    if (ch === '<') {
+      inTag = true;
+      continue;
+    }
+    if (ch === '>') {
+      if (!inTag) faults.push(`line ${line}: bare '>' in text`);
+      inTag = false;
+      continue;
+    }
+    if (inTag) continue;
+    if (ch === '&' && !ENTITY.test(xml.slice(i))) faults.push(`line ${line}: bare '&' in text`);
+  }
+  return faults;
+}
+
+test('generated plist ports are well-formed XML', async (t) => {
+  for (const rel of PLISTS) {
+    await t.test(`${rel} escapes every text node`, () => {
+      const faults = textNodeFaults(readFileSync(resolve(root, rel), 'utf8'));
+      assert.deepEqual(faults, [], `${rel}:\n${faults.join('\n')}`);
+    });
+  }
+
+  await t.test('the detector would have caught the 2.0.0 break', () => {
+    assert.deepEqual(textNodeFaults('<string>Number & Constant</string>'), ["line 1: bare '&' in text"]);
+    assert.deepEqual(textNodeFaults('<string>Number &amp; Constant</string>'), []);
+  });
+});
+
+test('plist emitters escape interpolated text', async (t) => {
+  const p = palette('standard');
+
+  await t.test('sublime escapes the theme name and every rule name', () => {
+    const out = sublime('Ampersand & <Angle>', p);
+    assert.match(out, /<string>Ampersand &amp; &lt;Angle&gt;<\/string>/);
+    assert.match(out, /<string>Number &amp; Constant<\/string>/);
+    assert.match(out, /<string>Type &amp; Class<\/string>/);
+    assert.deepEqual(textNodeFaults(out), []);
+  });
+
+  await t.test('iterm stays well-formed', () => {
+    assert.deepEqual(textNodeFaults(iterm(p)), []);
+  });
+});


### PR DESCRIPTION
The `.tmTheme` we tell Sublime Text users to drop into their Packages folder has not been a loadable file since the 2.0 redraw (`24bb62e`).

## The defect

`sublimeRule()` interpolates rule names straight into an XML text node. Two of them contain a literal ampersand:

```
sublime-text/The-Flying-Dutchman.tmTheme:75:   <string>Number & Constant</string>
sublime-text/The-Flying-Dutchman.tmTheme:119:  <string>Type & Class</string>
```

A bare `&` is not valid XML, and a `.tmTheme` is a plist parsed by a real XML parser. Confirmed against `main` at `71f2b3f`:

```
$ python3 -c "import plistlib; plistlib.load(open('sublime-text/The-Flying-Dutchman.tmTheme','rb'))"
xml.parsers.expat.ExpatError: not well-formed (invalid token): line 75, column 19
```

The file before the redraw had zero ampersands, so this is a 2.0 regression. `iterm/*.itermcolors` is the other plist port and happens to be clean — nothing in its data needs escaping.

## Why no check caught it

`check:themes` verifies the committed bytes match the palette and emitters. A malformed artifact matches its own malformed generator perfectly, so it round-trips clean forever — 9/9 green on every run since the break.

## The fix

- `xml()` in `scripts/emitters.mjs`, applied to every text node the two plist emitters interpolate: the Sublime theme name, each rule name and scope, and the iTerm dictionary keys.
- Regenerated `sublime-text/The-Flying-Dutchman.tmTheme` — the diff is exactly the two `&` → `&amp;`. `iterm/*.itermcolors` is byte-identical, which is the intended no-op.
- `test/plist-artifacts.test.mjs` walks the text nodes of both generated plists and asserts no bare `&`/`<`/`>`. Reverted onto the pre-fix tree it fails at exactly lines 75 and 119, so it is a real guard rather than a restatement of the fix.

## Verification

- `npm test` — 27 pass / 0 fail (was 20; +7 subtests)
- `npm run check:themes` — exit 0, all 9 generated files match, all roles pass WCAG
- `npm audit` — 0 vulnerabilities
- `plistlib.load` now parses the `.tmTheme` and reads back 26 settings entries; `.itermcolors` still parses

## Not a release change

`.vscodeignore` excludes `sublime-text/`, so `npx vsce package` still produces 9 files / 30.53 KB and the packaged extension is byte-identical. No version bump: this does not alter the pending 2.0.2 vsix, and #16 asks that 2.0.2 not be recut. Logged under `[Unreleased]`. The fix reaches Sublime users on merge, since that port is served from the repo, not the Marketplace.