### PR TITLE
Fix the Vim / Neovim port: this / self was never coloured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ All notable changes to The Flying Dutchman. Format based on
 
 ### Fixed
 
+- The Vim / Neovim port never coloured `this` / `self`. Its `" this / self"`
+  section re-emitted `Boolean` instead, so the coral role that VS Code
+  (`variable.language`) and Sublime (the `This` rule) both ship was missing, and
+  `Boolean` was defined twice — the second definition silently overrode the
+  first. The port now emits `@variable.builtin` in coral italic, and a new test
+  pins cross-port parity and rejects any duplicate `highlight` group;
+  `check:themes` could only prove the committed bytes matched the emitter, so a
+  wrong mapping round-tripped clean. Broken since the 2.0 redraw.
+
 - The Sublime Text port was not valid XML and would not load. The rule names
   `Number & Constant` and `Type & Class` wrote a bare `&` into the `.tmTheme`,
   which every plist parser rejects; it has been broken since the 2.0 redraw.

--- a/scripts/emitters.mjs
+++ b/scripts/emitters.mjs
@@ -685,8 +685,13 @@ export function vim(p) {
     H('diffAdded', p.green, null),
     H('diffRemoved', p.error, null),
     '',
+    // Parity with the VS Code `variable.language` rule and Sublime's `This`:
+    // `this`/`self` carry the coral role. Vim has no builtin group for it, so
+    // this is the Neovim treesitter name; Vim 9 accepts it as an inert group.
     '" this / self',
-    H('Boolean', p.constant, null),
+    H('@variable.builtin', p.coral, null, 'italic'),
+    '',
+    '" Markdown',
     H('markdownH1', p.func, null, 'bold'),
     H('markdownH2', p.func, null, 'bold'),
     H('markdownCode', p.property, null),

--- a/test/vim-port.test.mjs
+++ b/test/vim-port.test.mjs
@@ -1,0 +1,66 @@
+// Regression: check:themes only proves the committed vim file matches the
+// emitter, so a wrong mapping round-trips clean forever. 2.0.0 shipped a vim
+// port whose `" this / self"` section re-emitted `Boolean` — the this/self
+// role was silently missing, and one group was defined twice.
+
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import { sublime, vim, vscodeTheme } from '../scripts/emitters.mjs';
+import { palette } from '../scripts/palette.mjs';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const PORT = 'vim/colors/flying-dutchman.vim';
+
+// `highlight <group> guifg=... guibg=... gui=...` — one line per group.
+function highlights(source) {
+  const groups = new Map();
+  for (const line of source.split('\n')) {
+    const m = /^highlight (\S+) guifg=(\S+) guibg=(\S+) gui=(\S+)$/.exec(line);
+    if (m) groups.set(m[1], { fg: m[2], bg: m[3], gui: m[4] });
+  }
+  return groups;
+}
+
+test('vim port', async (t) => {
+  const p = palette('standard');
+  const committed = readFileSync(resolve(root, PORT), 'utf8');
+
+  await t.test('no highlight group is defined twice', () => {
+    const names = [...committed.matchAll(/^highlight (\S+)/gm)].map((m) => m[1]);
+    const dupes = names.filter((n, i) => names.indexOf(n) !== i);
+    assert.deepEqual([...new Set(dupes)], [], 'a later definition silently overrides the first');
+  });
+
+  await t.test('every highlight line is well-formed', () => {
+    const lines = committed.split('\n').filter((l) => l.startsWith('highlight ') && l !== 'highlight clear');
+    assert.ok(lines.length > 0);
+    for (const line of lines) {
+      assert.match(line, /^highlight \S+ guifg=(NONE|#[0-9a-f]{6}) guibg=(NONE|#[0-9a-f]{6}) gui=\S+$/, line);
+    }
+  });
+
+  await t.test('this / self carries the coral role, as in VS Code and Sublime', () => {
+    const group = highlights(committed).get('@variable.builtin');
+    assert.ok(group, 'the vim port defines no this/self group');
+    assert.equal(group.fg, p.coral);
+    assert.equal(group.gui, 'italic');
+
+    // The other two ports that colour this/self must agree on the role.
+    const rule = vscodeTheme('x', p).tokenColors.find((r) => r.scope?.includes?.('variable.language'));
+    assert.equal(rule.settings.foreground, p.coral);
+    assert.equal(rule.settings.fontStyle, 'italic');
+    const sublimeThis = new RegExp(`<string>This</string>[\\s\\S]*?<string>variable\\.language</string>[\\s\\S]*?<string>${p.coral}</string>[\\s\\S]*?<string>italic</string>`);
+    assert.match(sublime('x', p), sublimeThis);
+  });
+
+  await t.test('the detector would have caught the 2.0.0 break', () => {
+    const broken = 'highlight Boolean guifg=#e0c471 guibg=NONE gui=NONE\nhighlight Boolean guifg=#e0c471 guibg=NONE gui=NONE';
+    const names = [...broken.matchAll(/^highlight (\S+)/gm)].map((m) => m[1]);
+    assert.deepEqual(names.filter((n, i) => names.indexOf(n) !== i), ['Boolean']);
+    assert.equal(highlights(vim(p)).get('Boolean').fg, p.constant);
+  });
+});

--- a/vim/colors/flying-dutchman.vim
+++ b/vim/colors/flying-dutchman.vim
@@ -107,7 +107,9 @@ highlight diffAdded guifg=#5fc491 guibg=NONE gui=NONE
 highlight diffRemoved guifg=#e56661 guibg=NONE gui=NONE
 
 " this / self
-highlight Boolean guifg=#e0c471 guibg=NONE gui=NONE
+highlight @variable.builtin guifg=#e09585 guibg=NONE gui=italic
+
+" Markdown
 highlight markdownH1 guifg=#5cc4cc guibg=NONE gui=bold
 highlight markdownH2 guifg=#5cc4cc guibg=NONE gui=bold
 highlight markdownCode guifg=#8bc0d0 guibg=NONE gui=NONE


### PR DESCRIPTION
## The defect

`scripts/emitters.mjs` closes the vim emitter with a section commented
`" this / self"` — but the line under it re-emits `Boolean` with the constant
role. Two consequences in the shipped `vim/colors/flying-dutchman.vim`:

- **`this` / `self` is never coloured.** VS Code ships `variable.language` in
  coral italic and Sublime ships the same as its `This` rule. Vim and Neovim
  users get the default `Identifier` grey instead, so the three ports disagree
  on a role the palette calls out by name (`coral: 11, // living warmth (tags, this)`).
- **`Boolean` is defined twice** — identically, so the second definition is dead,
  but a duplicate `highlight` group means the later one silently wins.

The six markdown groups that follow were filed under that comment too, so the
section header described none of its contents.

Broken since the 2.0 redraw (`24bb62e`).

## Why no check caught it

Same blind spot #19 found in the plist ports: `check:themes` proves the committed
bytes match the emitter, and they did — the emitter itself was wrong, so the
mapping round-tripped clean forever. WCAG only reads palette roles, not which
group each role lands on.

## The fix

Emit `@variable.builtin` in coral italic — Neovim's treesitter group for
`this`/`self` — and give the markdown block its own `" Markdown"` header.

`test/vim-port.test.mjs` closes the detection gap:

- every `highlight` line parses as `highlight <group> guifg=… guibg=… gui=…`
- no group is defined twice
- the three ports that colour `this`/`self` agree on the role and font style
- a pinned reproduction of the 2.0.0 break, so the detector cannot silently rot

Reverting `emitters.mjs` alone fails 2 of the 4 subtests, so the test genuinely
holds the fix rather than restating it.

## Scope

**The `.vsix` is unaffected and this needs no version bump.** `.vscodeignore`
excludes `vim/`, and the three VS Code theme JSONs regenerate byte-identical —
the diff touches only the repo-served vim port. This does not disturb the
pending 2.0.2 publish in #16.

## Verification

- `npm test` — 32 pass, 0 fail
- `npm run check:themes` — all 9 generated files match; all roles pass WCAG
- Loaded the regenerated colorscheme in **Vim 9.1** (`-u NONE`, `termguicolors`):
  exits 0 with empty stderr, and reads back

  ```
  @variable.builtin xxx gui=italic guifg=#e09585
  Boolean           xxx guifg=#e0c471
  ```

  — this/self now coral italic, `Boolean` still holding the constant role.