### PR TITLE
Fix the Vim port: it errors on every :colorscheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ All notable changes to The Flying Dutchman. Format based on
 
 ### Fixed
 
+- The Vim / Neovim port raised an error on every `:colorscheme flying-dutchman`
+  in Vim. The `this` / `self` fix below emitted the Neovim treesitter group
+  `@variable.builtin` unguarded, and Vim only accepts `[A-Za-z0-9_]` in a group
+  name, so Vim 9.1 answered `W18: Invalid character in group name`. The group is
+  now wrapped in `if has('nvim')`: Neovim keeps the coral role, Vim loads
+  silently, and a new test rejects any group name Vim would parse and refuse.
+  Neovim was never affected.
+
 - The Vim / Neovim port never coloured `this` / `self`. Its `" this / self"`
   section re-emitted `Boolean` instead, so the coral role that VS Code
   (`variable.language`) and Sublime (the `This` rule) both ship was missing, and

--- a/scripts/emitters.mjs
+++ b/scripts/emitters.mjs
@@ -687,9 +687,15 @@ export function vim(p) {
     '',
     // Parity with the VS Code `variable.language` rule and Sublime's `This`:
     // `this`/`self` carry the coral role. Vim has no builtin group for it, so
-    // this is the Neovim treesitter name; Vim 9 accepts it as an inert group.
-    '" this / self',
-    H('@variable.builtin', p.coral, null, 'italic'),
+    // this is the Neovim treesitter name — and Vim does not accept it: group
+    // names are `[A-Za-z0-9_]` only, so a bare `@variable.builtin` raises
+    // `W18: Invalid character in group name` on every `:colorscheme`. Guarding
+    // it keeps the role in Neovim and keeps Vim silent; Vim has no portable
+    // group for this/self, so there it stays the plain `Identifier` colour.
+    '" this / self (Neovim only — Vim rejects `@` in a group name)',
+    "if has('nvim')",
+    '  ' + H('@variable.builtin', p.coral, null, 'italic'),
+    'endif',
     '',
     '" Markdown',
     H('markdownH1', p.func, null, 'bold'),

--- a/test/vim-port.test.mjs
+++ b/test/vim-port.test.mjs
@@ -1,7 +1,10 @@
 // Regression: check:themes only proves the committed vim file matches the
 // emitter, so a wrong mapping round-trips clean forever. 2.0.0 shipped a vim
 // port whose `" this / self"` section re-emitted `Boolean` — the this/self
-// role was silently missing, and one group was defined twice.
+// role was silently missing, and one group was defined twice. The fix then
+// emitted the Neovim treesitter group `@variable.builtin` unguarded, and Vim
+// rejects `@` and `.` in a group name: `:colorscheme flying-dutchman` raised
+// `W18: Invalid character in group name` for every Vim user.
 
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
@@ -15,14 +18,33 @@ import { palette } from '../scripts/palette.mjs';
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const PORT = 'vim/colors/flying-dutchman.vim';
 
-// `highlight <group> guifg=... guibg=... gui=...` — one line per group.
+// `highlight <group> guifg=... guibg=... gui=...` — one line per group, indented
+// when it sits inside an `if has('nvim')` block.
 function highlights(source) {
   const groups = new Map();
   for (const line of source.split('\n')) {
-    const m = /^highlight (\S+) guifg=(\S+) guibg=(\S+) gui=(\S+)$/.exec(line);
+    const m = /^ *highlight (\S+) guifg=(\S+) guibg=(\S+) gui=(\S+)$/.exec(line);
     if (m) groups.set(m[1], { fg: m[2], bg: m[3], gui: m[4] });
   }
   return groups;
+}
+
+// Vim only accepts `[A-Za-z0-9_]` in a highlight group name. Neovim's treesitter
+// groups (`@variable.builtin`) are legal there and nowhere else, so every one of
+// them has to sit inside an `if has('nvim')` block. Returns the group names Vim
+// itself would have to parse.
+function unguardedGroups(source) {
+  const names = [];
+  let guarded = 0;
+  for (const line of source.split('\n')) {
+    if (/^if has\('nvim'\)$/.test(line)) guarded += 1;
+    else if (/^endif$/.test(line)) guarded = Math.max(0, guarded - 1);
+    else if (guarded === 0) {
+      const m = /^ *highlight (\S+)/.exec(line);
+      if (m && m[1] !== 'clear') names.push(m[1]);
+    }
+  }
+  return names;
 }
 
 test('vim port', async (t) => {
@@ -30,17 +52,22 @@ test('vim port', async (t) => {
   const committed = readFileSync(resolve(root, PORT), 'utf8');
 
   await t.test('no highlight group is defined twice', () => {
-    const names = [...committed.matchAll(/^highlight (\S+)/gm)].map((m) => m[1]);
+    const names = [...committed.matchAll(/^ *highlight (\S+)/gm)].map((m) => m[1]);
     const dupes = names.filter((n, i) => names.indexOf(n) !== i);
     assert.deepEqual([...new Set(dupes)], [], 'a later definition silently overrides the first');
   });
 
   await t.test('every highlight line is well-formed', () => {
-    const lines = committed.split('\n').filter((l) => l.startsWith('highlight ') && l !== 'highlight clear');
+    const lines = committed.split('\n').filter((l) => /^ *highlight /.test(l) && l !== 'highlight clear');
     assert.ok(lines.length > 0);
     for (const line of lines) {
-      assert.match(line, /^highlight \S+ guifg=(NONE|#[0-9a-f]{6}) guibg=(NONE|#[0-9a-f]{6}) gui=\S+$/, line);
+      assert.match(line, /^ *highlight \S+ guifg=(NONE|#[0-9a-f]{6}) guibg=(NONE|#[0-9a-f]{6}) gui=\S+$/, line);
     }
+  });
+
+  await t.test('every group Vim parses is a name Vim accepts', () => {
+    const illegal = unguardedGroups(committed).filter((n) => !/^[A-Za-z0-9_]+$/.test(n));
+    assert.deepEqual(illegal, [], 'Vim raises W18: Invalid character in group name');
   });
 
   await t.test('this / self carries the coral role, as in VS Code and Sublime', () => {
@@ -48,6 +75,9 @@ test('vim port', async (t) => {
     assert.ok(group, 'the vim port defines no this/self group');
     assert.equal(group.fg, p.coral);
     assert.equal(group.gui, 'italic');
+
+    // Neovim-only, so Vim never parses the name it would reject.
+    assert.match(committed, /^if has\('nvim'\)\n  highlight @variable\.builtin .*\nendif$/m);
 
     // The other two ports that colour this/self must agree on the role.
     const rule = vscodeTheme('x', p).tokenColors.find((r) => r.scope?.includes?.('variable.language'));
@@ -59,8 +89,14 @@ test('vim port', async (t) => {
 
   await t.test('the detector would have caught the 2.0.0 break', () => {
     const broken = 'highlight Boolean guifg=#e0c471 guibg=NONE gui=NONE\nhighlight Boolean guifg=#e0c471 guibg=NONE gui=NONE';
-    const names = [...broken.matchAll(/^highlight (\S+)/gm)].map((m) => m[1]);
+    const names = [...broken.matchAll(/^ *highlight (\S+)/gm)].map((m) => m[1]);
     assert.deepEqual(names.filter((n, i) => names.indexOf(n) !== i), ['Boolean']);
     assert.equal(highlights(vim(p)).get('Boolean').fg, p.constant);
+  });
+
+  await t.test('the detector would have caught the unguarded treesitter group', () => {
+    const broken = '" this / self\nhighlight @variable.builtin guifg=#e09585 guibg=NONE gui=italic';
+    assert.deepEqual(unguardedGroups(broken), ['@variable.builtin']);
+    assert.deepEqual(unguardedGroups(vim(p)).filter((n) => !/^[A-Za-z0-9_]+$/.test(n)), []);
   });
 });

--- a/vim/colors/flying-dutchman.vim
+++ b/vim/colors/flying-dutchman.vim
@@ -106,8 +106,10 @@ highlight DiffText guifg=#6eb5d8 guibg=#202832 gui=NONE
 highlight diffAdded guifg=#5fc491 guibg=NONE gui=NONE
 highlight diffRemoved guifg=#e56661 guibg=NONE gui=NONE
 
-" this / self
-highlight @variable.builtin guifg=#e09585 guibg=NONE gui=italic
+" this / self (Neovim only — Vim rejects `@` in a group name)
+if has('nvim')
+  highlight @variable.builtin guifg=#e09585 guibg=NONE gui=italic
+endif
 
 " Markdown
 highlight markdownH1 guifg=#5cc4cc guibg=NONE gui=bold


### PR DESCRIPTION
## The break

`#20` gave the Vim / Neovim port its missing `this` / `self` colour by emitting the Neovim treesitter group `@variable.builtin`. The emitter comment claimed *"Vim 9 accepts it as an inert group"*. It does not — Vim only accepts `[A-Za-z0-9_]` in a highlight group name.

Reproduced against the real editor (Vim 9.1, patches 1-16/647/678/697) on `main` at `5b94a4c`:

```
$ vim -N -u NONE -es -c 'set rtp^=/tmp/fdvim' -c 'colorscheme flying-dutchman' \
      -c 'redir! > out.txt' -c 'silent! messages' -c 'redir END' -c 'qa!'

Error detected while processing .../colors/flying-dutchman.vim:
line  110:
W18: Invalid character in group name
```

Every Vim user got that on `:colorscheme flying-dutchman`. Neovim was never affected — the group is legal there and still resolves. The rest of the script survives the error, so the visible damage is the error itself plus `this` / `self` staying uncoloured under Vim.

## The fix

Wrap the group in `if has('nvim')`. Neovim keeps the coral role; Vim skips the block without ever parsing the name it would refuse. Vim has no portable group for `this` / `self`, so under Vim it stays the plain `Identifier` colour — same as before #20, minus the error.

Same run after the fix — the message log is empty and the other groups still apply:

```
markdownItalic xxx gui=italic guifg=#75acd1
Comment        xxx gui=italic guifg=#6a7b8a
```

## Why the gate missed it

`check:themes` proves the committed bytes match the emitter. It cannot tell whether the target editor can load the result — so a wrong mapping (#20) and now an unparseable one both round-tripped clean. This adds the missing class of assertion: `every group Vim parses is a name Vim accepts`, plus a detector test on the exact broken string.

Checked out at `origin/main` and swapped in the pre-fix artifact, the new assertion fails as it should:

```
not ok 3 - every group Vim parses is a name Vim accepts
    Vim raises W18: Invalid character in group name
```

## Verification

- `npm test` — 34 pass, 0 fail (was 32; +2 new)
- `npm run check:themes` — all roles pass WCAG, no artifact drift
- Real Vim 9.1 loads the regenerated colorscheme with an empty message log
- Neovim is not installed on the build host, so the `has('nvim')` branch was not executed end to end; it is pinned statically by the parity test instead

Generated file regenerated via `node scripts/build-themes.mjs`, never hand-edited. Ports are `.vscodeignore`d, so the `.vsix` is unchanged and no version bump is needed.